### PR TITLE
Increase data-fetch timeout

### DIFF
--- a/lib/central_settings_client/cache_record.rb
+++ b/lib/central_settings_client/cache_record.rb
@@ -1,6 +1,6 @@
 module CentralSettingsClient
   class CacheRecord
-    TIMEOUT = 0.5 # Seconds
+    TIMEOUT = 1.5 # Seconds
     EXPIRATION_TIME = 3600 # One hour in seconds
 
     attr_accessor :expires_at, :last_computed_value, :block


### PR DESCRIPTION
Everything is ok except timeout.

The error looks random because it happens only if `central-settings` is "cold".
After doing some benchmarking i found out, that on my machine fetching and parsing data using cold `central-settings` took ~ 0.7sec, and when app is heated up ~ 0.3 sec.

I made timeout 1.5 sec because i don't know how to scale my machine to the production one, but i think it's okay to have a large timeout, because as far as i know we fetch settings only on startup.
